### PR TITLE
Updated task name to (channels_presence.tasks.prune_presences) in tasks.py

### DIFF
--- a/channels_presence/tasks.py
+++ b/channels_presence/tasks.py
@@ -2,7 +2,7 @@ from celery import shared_task
 
 from channels_presence.models import Room
 
-@shared_task(name='channels_presence.tasks.prune_presence')
+@shared_task(name='channels_presence.tasks.prune_presences')
 def prune_presence():
     Room.objects.prune_presences()
 


### PR DESCRIPTION
Hi @yourcelf ,
First of all, thank you so much for putting up django-channels-presence its really helpful in tracking presence in django-channels. I found out in the docs the prune_presence task name is given as `channels_presence.tasks.prune_presences` and the in the task.py file the task prune_presence is named `channels_presence.tasks.prune_presence` so I renamed the prune_presence task in task.py to `channels_presence.tasks.prune_presences`. otherwise, it was giving 
```
KeyError: 'channels_presence.tasks.prune_presences'
```

Thank you so much for your time. 
have a nice day!