### PR TITLE
Fixed apps.py

### DIFF
--- a/channels_presence/apps.py
+++ b/channels_presence/apps.py
@@ -3,3 +3,4 @@ from django.apps import AppConfig
 
 class RoomsConfig(AppConfig):
     name = 'rooms'
+    default = False


### PR DESCRIPTION
I'm working on a Django channels project Django=3.2.2 and I had the error " ImproperlyConfigured(
django.core.exceptions.ImproperlyConfigured: Cannot import 'rooms'. Check that 'channels_presence.apps.RoomsConfig.name' is correct.". I have installed channels_presense and added it to apps in settings.py

I noticed that after adding default=False in apps.py fixed it.
Please merge so I won't have to use a local version of the package and I can always update